### PR TITLE
hyper cli for docker-slave-plugin, two container version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </scm>
 
     <properties>
-        <jenkins.version>1.651.2</jenkins.version>
+        <jenkins.version>2.7.1</jenkins.version>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 
@@ -93,10 +93,9 @@
             <version>1.3.1</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>docker-java-api</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
-            <optional>true</optional>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java</artifactId>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
+++ b/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
@@ -19,13 +19,18 @@ public class DefaultDockerHostSource extends DockerHostSource {
 
     private final DockerServerEndpoint dockerServerEndpoint;
 
+    private final String hyperAccessKey;
+    private final String hyperSecretKey;
+
     public DefaultDockerHostSource() {
-        this(new DockerServerEndpoint(null, null));
+        this(new DockerServerEndpoint(null, null), null, null);
     }
 
     @DataBoundConstructor
-    public DefaultDockerHostSource(DockerServerEndpoint dockerServerEndpoint) {
+    public DefaultDockerHostSource(DockerServerEndpoint dockerServerEndpoint, String hyperAccessKey, String hyperSecretKey) {
         this.dockerServerEndpoint = dockerServerEndpoint;
+        this.hyperAccessKey = hyperAccessKey;
+        this.hyperSecretKey = hyperSecretKey;
     }
 
     public DockerServerEndpoint getDockerServerEndpoint() {
@@ -34,7 +39,7 @@ public class DefaultDockerHostSource extends DockerHostSource {
 
     @Override
     public DockerHostConfig getDockerHost(Job job) throws IOException, InterruptedException {
-        return new DockerHostConfig(dockerServerEndpoint, job);
+        return new DockerHostConfig(dockerServerEndpoint, hyperAccessKey, hyperSecretKey, job);
     }
 
     @Extension

--- a/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
+++ b/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
@@ -39,6 +39,10 @@ public class DefaultDockerHostSource extends DockerHostSource {
     }
 
     private void SaveConfig(String hyperAccessKey, String hyperSecretKey) {
+        if (hyperAccessKey == null || hyperSecretKey == null) {
+            return;
+        }
+
         String jsonStr = "{\"clouds\": {" +
                 "\"tcp://us-west-1.hyper.sh:443\": {" +
                 "\"accesskey\": " + "\"" + hyperAccessKey + "\"," +

--- a/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
+++ b/src/main/java/it/dockins/dockerslaves/DefaultDockerHostSource.java
@@ -2,6 +2,7 @@ package it.dockins.dockerslaves;
 
 import hudson.Extension;
 import hudson.model.Job;
+import hudson.util.FormValidation;
 import it.dockins.dockerslaves.spi.DockerHostConfig;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
@@ -10,6 +11,9 @@ import it.dockins.dockerslaves.spi.DockerHostSource;
 import it.dockins.dockerslaves.spi.DockerHostSourceDescriptor;
 
 import javax.annotation.Nonnull;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -31,6 +35,67 @@ public class DefaultDockerHostSource extends DockerHostSource {
         this.dockerServerEndpoint = dockerServerEndpoint;
         this.hyperAccessKey = hyperAccessKey;
         this.hyperSecretKey = hyperSecretKey;
+        this.SaveConfig(hyperAccessKey, hyperSecretKey);
+    }
+
+    private void SaveConfig(String hyperAccessKey, String hyperSecretKey) {
+        String jsonStr = "{\"clouds\": {" +
+                "\"tcp://us-west-1.hyper.sh:443\": {" +
+                "\"accesskey\": " + "\"" + hyperAccessKey + "\"," +
+                "\"secretkey\": " + "\"" + hyperSecretKey + "\"" +
+                "}" +
+                "}" +
+                "}";
+        BufferedWriter writer = null;
+        String configPath;
+        String jenkinsHome = System.getenv("HUDSON_HOME");
+
+        if (jenkinsHome == null) {
+            String home = System.getenv("HOME");
+            configPath = home + "/.hyper/config.json";
+            File hyperPath = new File(home + "/.hyper");
+            try {
+                if (!hyperPath.exists()) {
+                    hyperPath.mkdir();
+                }
+            } catch (SecurityException e) {
+                e.printStackTrace();
+            }
+        } else {
+            File hyperPath = new File(jenkinsHome +"/.hyper");
+            try {
+                if (!hyperPath.exists()) {hyperPath.mkdir();
+                }
+            } catch (SecurityException e) {
+                e.printStackTrace();
+            }
+            configPath = jenkinsHome + "/.hyper/config.json";
+        }
+
+
+        File config = new File(configPath);
+        if(!config.exists()){
+            try {
+                config.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        try {
+            writer = new BufferedWriter(new FileWriter(config));
+            writer.write(jsonStr);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }finally {
+            try {
+                if(writer != null){
+                    writer.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     public DockerServerEndpoint getDockerServerEndpoint() {

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
@@ -336,7 +336,7 @@ public class CliHyperDriver implements DockerDriver {
                 .add(image);
         int status = 0;
 
-        if (image == "yao/jenkins-slave") {
+        if (image == hyperJenkinsImage) {
             status =  launchDockerCLI(launcher, args)
                 .stdout(launcher.getListener().getLogger()).join();
         } else {
@@ -355,7 +355,7 @@ public class CliHyperDriver implements DockerDriver {
                 .add("inspect")
                 .add("-f", "'{{.Id}}'")
                 .add(image);
-        if (image == "yao/jenkins-slave") {
+        if (image == hyperJenkinsImage) {
             return launchDockerCLI(launcher, args)
                     .stdout(launcher.getListener().getLogger()).join() == 0;
         } else {

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
@@ -1,0 +1,412 @@
+/*
+ * The MIT License
+ *  
+ *  Copyright (c) 2015, CloudBees, Inc.
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package it.dockins.dockerslaves.drivers;
+
+import hudson.Launcher;
+import hudson.Proc;
+import hudson.model.Slave;
+import hudson.model.TaskListener;
+import hudson.org.apache.tools.tar.TarOutputStream;
+import hudson.slaves.CommandLauncher;
+import hudson.slaves.SlaveComputer;
+import hudson.util.ArgumentListBuilder;
+import it.dockins.dockerslaves.ContainerInstance;
+import it.dockins.dockerslaves.DockerSlave;
+import it.dockins.dockerslaves.ProvisionQueueListener;
+import it.dockins.dockerslaves.spi.DockerDriver;
+import it.dockins.dockerslaves.spi.DockerHostConfig;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.tools.tar.TarEntry;
+import org.apache.tools.tar.TarInputStream;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author <a href="mailto:yoann.dubreuil@gmail.com">Yoann Dubreuil</a>
+ */
+public class CliHyperDriver implements DockerDriver {
+
+    private final boolean verbose;
+
+    final DockerHostConfig dockerHost;
+
+    private final String hyperJenkinsImage;
+
+    public CliHyperDriver(DockerHostConfig dockerHost) throws IOException, InterruptedException {
+        this.dockerHost = dockerHost;
+        verbose = true;
+        hyperJenkinsImage = "hyperhq/jenkins-slave";
+    }
+
+    @Override
+    public void close() throws IOException {
+        dockerHost.close();
+    }
+
+    @Override
+    public String createVolume(Launcher launcher, String driver, Collection<String> driverOpts) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("volume", "create");
+
+        if (driver != null) {
+            args.add("--driver", driver);
+            if (driverOpts != null) {
+                for (String opt : driverOpts) {
+                    args.add(opt);
+                }
+            }
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        final String volume = out.toString("UTF-8").trim();
+
+        if (status != 0) {
+            throw new IOException("Failed to run docker image");
+        }
+
+        return volume;
+    }
+
+    @Override
+    public boolean hasVolume(Launcher launcher, String name) throws IOException, InterruptedException {
+        if (StringUtils.isEmpty(name)) {
+            return false;
+        }
+
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("volume", "inspect", "-f", "'{{.Name}}'", name);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        if (status != 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+
+    @Override
+    public boolean hasContainer(Launcher launcher, String id) throws IOException, InterruptedException {
+        if (StringUtils.isEmpty(id)) {
+            return false;
+        }
+
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("inspect", "-f", "'{{.Id}}'", id);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        if (status != 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public ContainerInstance createRemotingContainer(Launcher launcher, String image, String workdir) throws IOException, InterruptedException {
+
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("create", "--interactive")
+
+                // We disable container logging to sdout as we rely on this one as transport for jenkins remoting
+                .add("--log-driver=none")
+                .add("-e", "ACCESS_KEY=" + dockerHost.getHyperAccessKey())
+                .add("-e", "SECRET_KEY=" + dockerHost.getHyperSecretKey())
+
+                .add("--env", "TMPDIR="+ DockerSlave.SLAVE_ROOT+".tmp")
+                .add("--volume", workdir+":"+ DockerSlave.SLAVE_ROOT)
+                .add("--workdir", DockerSlave.SLAVE_ROOT)
+                .add(hyperJenkinsImage)
+                .add("java")
+
+                // set TMP directory within the /home/jenkins/ volume so it can be shared with other containers
+                .add("-Djava.io.tmpdir="+ DockerSlave.SLAVE_ROOT+".tmp")
+                .add("-jar").add(DockerSlave.SLAVE_ROOT+"slave.jar");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        String containerId = out.toString("UTF-8").trim();
+
+        if (status != 0) {
+            throw new IOException("Failed to create docker image");
+        }
+
+        putFileContent(launcher, containerId, DockerSlave.SLAVE_ROOT, "slave.jar", new Slave.JnlpJar("slave.jar").readFully());
+        return new ContainerInstance(hyperJenkinsImage, containerId);
+    }
+
+    @Override
+    public void launchRemotingContainer(final SlaveComputer computer, TaskListener listener, ContainerInstance remotingContainer) {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("start")
+                .add("--interactive", "--attach", remotingContainer.getId());
+        prependArgs(args);
+        CommandLauncher launcher = new CommandLauncher(args.toString(), dockerHost.getEnvironment());
+        launcher.launch(computer, listener);
+    }
+
+    @Override
+    public ContainerInstance createAndLaunchBuildContainer(Launcher launcher, String image, ContainerInstance remotingContainer) throws IOException, InterruptedException {
+        ContainerInstance buildContainer = new ContainerInstance(image);
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("exec")
+                .add(remotingContainer.getId())
+                .add("hyper")
+                .add("run", "-d")
+                .add("-v", DockerSlave.SLAVE_ROOT + ":" + DockerSlave.SLAVE_ROOT)
+                .add(image);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        final String containerId = out.toString("UTF-8").trim();
+        buildContainer.setId(containerId);
+
+        return buildContainer;       
+    }
+
+    protected void getFileContent(Launcher launcher, String containerId, String filename, OutputStream outputStream) throws IOException, InterruptedException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("cp", containerId + ":" + filename, "-");
+
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        if (status != 0) {
+            throw new IOException("Failed to get file");
+        }
+
+        TarInputStream tar = new TarInputStream(new ByteArrayInputStream(out.toByteArray()));
+        tar.getNextEntry();
+        tar.copyEntryContents(outputStream);
+        tar.close();
+    }
+
+    protected int putFileContent(Launcher launcher, String containerId, String path, String filename, byte[] content) throws IOException, InterruptedException {
+        return putFileContent(launcher, containerId, path, filename, content, null);
+    }
+
+    protected int putFileContent(Launcher launcher, String containerId, String path, String filename, byte[] content, Integer mode) throws IOException, InterruptedException {
+        TarEntry entry = new TarEntry(filename);
+        entry.setUserId(0);
+        entry.setGroupId(0);
+        entry.setSize(content.length);
+        if (mode != null) {
+            entry.setMode(mode);
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        TarOutputStream tar = new TarOutputStream(out);
+        tar.putNextEntry(entry);
+        tar.write(content);
+        tar.closeEntry();
+        tar.close();
+
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("cp", "-", containerId + ":" + path);
+
+        return launchDockerCLI(launcher, args)
+                .stdin(new ByteArrayInputStream(out.toByteArray()))
+                .stderr(launcher.getListener().getLogger()).join();
+    }
+
+    @Override
+    public Proc execInContainer(Launcher launcher, String containerId, Launcher.ProcStarter starter) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("exec", containerId);
+
+        args.add("env").add(starter.envs());
+
+        List<String> originalCmds = starter.cmds();
+        boolean[] originalMask = starter.masks();
+        for (int i = 0; i < originalCmds.size(); i++) {
+            boolean masked = originalMask == null ? false : i < originalMask.length ? originalMask[i] : false;
+            args.add(originalCmds.get(i), masked);
+        }
+
+        Launcher.ProcStarter procStarter = launchHyperCLI(launcher, args);
+
+        if (starter.stdout() != null) {
+            procStarter.stdout(starter.stdout());
+        }
+
+        return procStarter.start();
+    }
+
+    @Override
+    public int removeContainer(Launcher launcher, ContainerInstance instance) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("rm", "-f", "-v", instance.getId());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int status = 0;
+
+        if (instance.getImageName() == hyperJenkinsImage) {
+            status = launchDockerCLI(launcher, args)
+                    .stdout(out).stderr(launcher.getListener().getLogger()).join();
+        } else {
+            status = launchHyperCLI(launcher, args)
+                    .stdout(out).stderr(launcher.getListener().getLogger()).join();            
+        }
+
+        return status;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(ProvisionQueueListener.class.getName());
+
+    @Override
+    public void launchSideContainer(Launcher launcher, ContainerInstance instance, ContainerInstance remotingContainer) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("create")
+                .add("--volumes-from", remotingContainer.getId())
+                .add("--net=container:" + remotingContainer.getId())
+                .add("--ipc=container:" + remotingContainer.getId())
+                .add(instance.getImageName());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int status = launchDockerCLI(launcher, args)
+                .stdout(out).stderr(launcher.getListener().getLogger()).join();
+
+        final String containerId = out.toString("UTF-8").trim();
+        instance.setId(containerId);
+
+        if (status != 0) {
+            throw new IOException("Failed to run docker image");
+        }
+
+        launchDockerCLI(launcher, new ArgumentListBuilder()
+                .add("start", containerId)).start();
+    }
+
+    @Override
+    public void pullImage(Launcher launcher, String image) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("pull")
+                .add(image);
+        int status = 0;
+
+        if (image == "yao/jenkins-slave") {
+            status =  launchDockerCLI(launcher, args)
+                .stdout(launcher.getListener().getLogger()).join();
+        } else {
+            status =  launchHyperCLI(launcher, args)
+                .stdout(launcher.getListener().getLogger()).join();
+        }
+
+        if (status != 0) {
+            throw new IOException("Failed to pull image " + image);
+        }
+    }
+
+    @Override
+    public boolean checkImageExists(Launcher launcher, String image) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("inspect")
+                .add("-f", "'{{.Id}}'")
+                .add(image);
+        if (image == "yao/jenkins-slave") {
+            return launchDockerCLI(launcher, args)
+                    .stdout(launcher.getListener().getLogger()).join() == 0;
+        } else {
+             return launchHyperCLI(launcher, args)
+                    .stdout(launcher.getListener().getLogger()).join() == 0;           
+        }
+    }
+
+    @Override
+    public int buildDockerfile(Launcher launcher, String dockerfilePath, String tag, boolean pull)  throws IOException, InterruptedException {
+        String pullOption = "--pull=";
+        if (pull) {
+            pullOption += "true";
+        } else {
+            pullOption += "false";
+        }
+        ArgumentListBuilder args = new ArgumentListBuilder()
+                .add("build")
+                .add(pullOption)
+                .add("-t", tag)
+                .add(dockerfilePath);
+
+        return launchDockerCLI(launcher, args)
+                .stdout(launcher.getListener().getLogger()).join();
+    }
+
+    public void prependArgs(ArgumentListBuilder args){
+        final DockerServerEndpoint endpoint = dockerHost.getEndpoint();
+        if (endpoint.getUri() != null) {
+            args.prepend("-H", endpoint.getUri());
+        } else {
+            LOGGER.log(Level.FINE, "no specified docker host");
+        }
+
+        args.prepend("docker");
+    }
+
+    private Launcher.ProcStarter launchDockerCLI(Launcher launcher, ArgumentListBuilder args) {
+        prependArgs(args);
+
+        return launcher.launch()
+                .envs(dockerHost.getEnvironment())
+                .cmds(args)
+                .quiet(!verbose);
+    }
+
+    private Launcher.ProcStarter launchHyperCLI(Launcher launcher, ArgumentListBuilder args) {
+        args.prepend("hyper");
+
+        return launcher.launch()
+                .cmds(args)
+                .quiet(!verbose);
+    }
+}

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
@@ -402,8 +402,18 @@ public class CliHyperDriver implements DockerDriver {
                 .quiet(!verbose);
     }
 
+    public void prependHyperArgs(ArgumentListBuilder args) {
+        String hyperCliPath = System.getenv("HOME") + "/hyper";
+
+        if (System.getenv("HUDSON_HOME") != null)  {
+            hyperCliPath = System.getenv("HUDSON_HOME") + "/bin/hyper";
+        }
+
+        args.prepend(hyperCliPath);
+    }
+
     private Launcher.ProcStarter launchHyperCLI(Launcher launcher, ArgumentListBuilder args) {
-        args.prepend("hyper");
+        prependHyperArgs(args);
 
         return launcher.launch()
                 .cmds(args)

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliHyperDriver.java
@@ -97,7 +97,7 @@ public class CliHyperDriver implements DockerDriver {
         final String volume = out.toString("UTF-8").trim();
 
         if (status != 0) {
-            throw new IOException("Failed to run docker image");
+            throw new IOException("Failed to create volume");
         }
 
         return volume;
@@ -175,7 +175,7 @@ public class CliHyperDriver implements DockerDriver {
         String containerId = out.toString("UTF-8").trim();
 
         if (status != 0) {
-            throw new IOException("Failed to create docker image");
+            throw new IOException("Failed to create remoting container");
         }
 
         putFileContent(launcher, containerId, DockerSlave.SLAVE_ROOT, "slave.jar", new Slave.JnlpJar("slave.jar").readFully());

--- a/src/main/java/it/dockins/dockerslaves/drivers/PlainDockerAPIDockerDriverFactory.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/PlainDockerAPIDockerDriverFactory.java
@@ -67,6 +67,15 @@ public class PlainDockerAPIDockerDriverFactory extends DockerDriverFactory {
             DockerDriver forDockerHost(DockerHostConfig dockerHost) throws IOException, InterruptedException {
                 return new CliDockerDriver(dockerHost);
             }
+        },
+        HYPER_CLI {
+             String getDisplayName() {
+                return "Hyper CLI";
+            }
+
+            DockerDriver forDockerHost(DockerHostConfig dockerHost) throws IOException, InterruptedException {
+                return new CliHyperDriver(dockerHost);
+            }           
         };
 
         abstract String getDisplayName();

--- a/src/main/java/it/dockins/dockerslaves/spi/DockerHostConfig.java
+++ b/src/main/java/it/dockins/dockerslaves/spi/DockerHostConfig.java
@@ -24,16 +24,30 @@ public class DockerHostConfig implements Closeable {
     /** Docker Host's daemon endpoint */
     private final DockerServerEndpoint endpoint;
 
+    /**Hyper's ACCESS_KEY and SECRET_KEY*/
+    public final String hyperAccessKey;
+    public final String hyperSecretKey;
+
     /** Docker API access keys  */
     private final KeyMaterial keys;
 
-    public DockerHostConfig(DockerServerEndpoint endpoint, Item context) throws IOException, InterruptedException {
+    public DockerHostConfig(DockerServerEndpoint endpoint, String hyperAccessKey, String hyperSecretKey, Item context) throws IOException, InterruptedException {
         this.endpoint = endpoint;
+        this.hyperAccessKey = hyperAccessKey;
+        this.hyperSecretKey = hyperSecretKey;
         keys = endpoint.newKeyMaterialFactory(context, Jenkins.getActiveInstance().getChannel()).materialize();
     }
 
     public DockerServerEndpoint getEndpoint() {
         return endpoint;
+    }
+
+    public String getHyperAccessKey() {
+        return hyperAccessKey;
+    }
+
+    public String getHyperSecretKey() {
+        return hyperSecretKey;
     }
 
     public EnvVars getEnvironment() {

--- a/src/main/resources/it/dockins/dockerslaves/DefaultDockerHostSource/config.jelly
+++ b/src/main/resources/it/dockins/dockerslaves/DefaultDockerHostSource/config.jelly
@@ -33,7 +33,7 @@
    </f:entry>
 
    <f:entry title="Hyper Secret_Key" field="hyperSecretKey">
-     <f:textbox />
+     <f:password />
    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/it/dockins/dockerslaves/DefaultDockerHostSource/config.jelly
+++ b/src/main/resources/it/dockins/dockerslaves/DefaultDockerHostSource/config.jelly
@@ -28,4 +28,12 @@
 
    <f:property field="dockerServerEndpoint"/>
 
+   <f:entry title="Hyper Access_Key" field="hyperAccessKey">
+     <f:textbox />
+   </f:entry>
+
+   <f:entry title="Hyper Secret_Key" field="hyperSecretKey">
+     <f:textbox />
+   </f:entry>
+
 </j:jelly>

--- a/src/main/resources/it/dockins/dockerslaves/DockerSlaves/global.jelly
+++ b/src/main/resources/it/dockins/dockerslaves/DockerSlaves/global.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This Jelly script is used to produce the global configuration option.
+
+    Jenkins uses a set of tag libraries to provide uniformity in forms.
+    To determine where this tag is defined, first check the namespace URI,
+    and then look under $JENKINS/views/. For example, <f:section> is defined
+    in $JENKINS/views/lib/form/section.jelly.
+
+    It's also often useful to just check other similar scripts to see what
+    tags they use. Views are always organized according to its owner class,
+    so it should be straightforward to find them.
+  -->
+
+    <f:section title="Hyper Install">
+        <f:validateButton
+            title="${%Download Hypercli}" progress="${%Downloading...}"
+            method="downloadHypercli"/>
+    </f:section>
+</j:jelly>


### PR DESCRIPTION
This PR implements the Hyper_ driver for docker-slave-plugin.

First I launch a slave conatiner just like the "docker cli" driver, the difference is the image "hyperhq/jenkins-slave" which is based on "jenkinsci/slave", but already has hyper cli in it.

After that, I launch build container through the cmd like "docker exec containerID hyper run -d -v /home/jenkins:/home/jenkins busybox". Especially, the flag "-v " means copy the content in "/home/jenkins" of slave container into the "/home/jenkins" of build container.And the effect is same as "--volume-from".

Finally I use "hyper exec" to execute the job in build container just like "docker cli" driver.