### PR TITLE
[JENKINS-38265] don’t propagate removing env into ProcStarter

### DIFF
--- a/src/main/java/it/dockins/dockerslaves/DockerComputer.java
+++ b/src/main/java/it/dockins/dockerslaves/DockerComputer.java
@@ -25,6 +25,7 @@
 
 package it.dockins.dockerslaves;
 
+import hudson.EnvVars;
 import it.dockins.dockerslaves.api.OneShotComputer;
 import hudson.slaves.ComputerLauncher;
 import it.dockins.dockerslaves.spi.DockerProvisioner;
@@ -55,6 +56,13 @@ public class DockerComputer extends OneShotComputer {
     @Override
     public Boolean isUnix() {
         return Boolean.TRUE;
+    }
+
+
+    @Override
+    public EnvVars getEnvironment() throws IOException, InterruptedException {
+        // call to EnvVars#getRemote like standard Computer does, we get remoting container env, not build container one;
+        return new EnvVars();
     }
 
     @Override

--- a/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
+++ b/src/main/java/it/dockins/dockerslaves/drivers/CliDockerDriver.java
@@ -185,8 +185,8 @@ public class CliDockerDriver implements DockerDriver {
         Container buildContainer = new Container(image);
         ArgumentListBuilder args = new ArgumentListBuilder()
                 .add("create")
-                .add("--env", "TMPDIR=/home/jenkins/.tmp")
-                .add("--workdir", "/home/jenkins")
+                .add("--env", "TMPDIR="+SLAVE_ROOT+".tmp")
+                .add("--workdir", SLAVE_ROOT)
                 .add("--volumes-from", remotingContainer.getId())
                 .add("--net=container:" + remotingContainer.getId())
                 .add("--ipc=container:" + remotingContainer.getId())
@@ -296,6 +296,7 @@ public class CliDockerDriver implements DockerDriver {
         if (starter.pwd() != null) {
             args.add("/trampoline", "cdexec", starter.pwd().getRemote());
         }
+
         args.add("env").add(starter.envs());
 
         List<String> originalCmds = starter.cmds();


### PR DESCRIPTION
Would be even better to collect `env` from Build Container.
But then need the build container to run earlier